### PR TITLE
set focus on renderer to enable user input when embedded in an iframe

### DIFF
--- a/fraction-hero/js/rendering.js
+++ b/fraction-hero/js/rendering.js
@@ -17,6 +17,9 @@ function setup_rendering() {
 	// add the renderer view element to the DOM
 	document.body.appendChild(renderer.view);
 
+	// set focus on renderer to enable user input when embedded in an iframe
+	renderer.view.tabIndex = 0;
+	renderer.view.focus();
 }
 
 


### PR DESCRIPTION
Hey Joe,

This PR is just to show how you can force the renderer to have focus when embedded - you are welcome to delete. Visibull currently relies on iframes to display external content but we are working on iframe-less embeds so in the future we hope to remove these types of hacks!

Jordan
